### PR TITLE
Add support for iptables_nft, improve reliability

### DIFF
--- a/bin/client_init.sh
+++ b/bin/client_init.sh
@@ -40,6 +40,9 @@ GATEWAY_IP="$(dig +short "$GATEWAY_NAME" "@${K8S_DNS_IP}")"
 NAT_ENTRY="$(grep "$(hostname)" /config/nat.conf || true)"
 VXLAN_GATEWAY_IP="${VXLAN_IP_NETWORK}.1"
 
+# Make sure there is correct route for gateway
+ip route add "$GATEWAY_IP" via "$K8S_GW_IP"
+
 # For debugging reasons print some info
 ip addr
 ip route


### PR DESCRIPTION
Cloned from https://github.com/k8s-at-home/pod-gateway/pull/43
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**
Add support for iptables_nft that are used by default on modern systems.
Skip ip rule addition when already exists, might happen when init container is restarted because of previous failure.
Make sure there is correct route for gateway ip in case it wasn't covered by `NOT_ROUTED_TO_GATEWAY_CIDRS`.
<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**
Beeing able to use pod-gatweay on modern systems and improve reliability
<!-- What benefits will be realized by the code change? -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #42 

**Additional information**
iptables_nft must be explicitly enabled by setting `IPTABLES_NFT=yes` therefore default behavior is not altered.
<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
