### PR TITLE
Fix/gateway reconnect

### DIFF
--- a/bin/client_init.sh
+++ b/bin/client_init.sh
@@ -41,7 +41,10 @@ NAT_ENTRY="$(grep "$(hostname)" /config/nat.conf || true)"
 VXLAN_GATEWAY_IP="${VXLAN_IP_NETWORK}.1"
 
 # Make sure there is correct route for gateway
-ip route add "$GATEWAY_IP" via "$K8S_GW_IP"
+# K8S_GW_IP is not set if scipt is called again and route still exist on pod
+if [ -n "$K8S_GW_IP" ]; then
+    ip route add "$GATEWAY_IP" via "$K8S_GW_IP"
+fi
 
 # For debugging reasons print some info
 ip addr

--- a/bin/client_init.sh
+++ b/bin/client_init.sh
@@ -41,7 +41,7 @@ NAT_ENTRY="$(grep "$(hostname)" /config/nat.conf || true)"
 VXLAN_GATEWAY_IP="${VXLAN_IP_NETWORK}.1"
 
 # Make sure there is correct route for gateway
-# K8S_GW_IP is not set if scipt is called again and route still exist on pod
+# K8S_GW_IP is not set when script is called again and the route should still exist on the pod anyway.
 if [ -n "$K8S_GW_IP" ]; then
     ip route add "$GATEWAY_IP" via "$K8S_GW_IP"
 fi


### PR DESCRIPTION
**Description of the change**:

To use the reconnect functionality I had to make a small adjustment otherwise the Sidecar stays in `CrashLoopBackOff` and restarts constantly. See log below:

```
ip route add 10.42.0.72 via ''
Error: inet address is expected rather than "".
Stream closed EOF for vpn-apps/vpn-terminal-848c69dbf9-htqjj (gateway-sidecar.
```

And as a result, a connection to the gateway can no longer be established.

Description: Because the pod already has the route setting the default route does not longer exist and the script is not able to determine the variable `K8S_GW_IP`. But we don't need this in this case anyway because the corresponding routing setting is already set.

**Possible drawbacks**:

None
