### PR TITLE
Make dnssec support optional

### DIFF
--- a/bin/gateway_sidecar.sh
+++ b/bin/gateway_sidecar.sh
@@ -39,14 +39,17 @@ log-facility=-
 # Clear DNS cache on reload
 clear-on-reload
 
-# Enable DNSSEC validation and caching
-conf-file=/usr/share/dnsmasq/trust-anchors.conf
-dnssec
-
 # /etc/resolv.conf cannot be monitored by dnsmasq since it is in a different file system
 # and dnsmasq monitors directories only
 # copy_resolv.sh is used to copy the file on changes
 resolv-file=${RESOLV_CONF_COPY}
+EOF
+
+if [[ ${GATEWAY_ENABLE_DNSSEC} == true ];then
+cat << EOF >> /etc/dnsmasq.d/pod-gateway.conf
+  # Enable DNSSEC validation and caching
+  conf-file=/usr/share/dnsmasq/trust-anchors.conf
+  dnssec
 EOF
 
 for local_cidr in $DNS_LOCAL_CIDRS; do

--- a/bin/gateway_sidecar.sh
+++ b/bin/gateway_sidecar.sh
@@ -45,12 +45,13 @@ clear-on-reload
 resolv-file=${RESOLV_CONF_COPY}
 EOF
 
-if [[ ${GATEWAY_ENABLE_DNSSEC} == true ];then
+if [[ ${GATEWAY_ENABLE_DNSSEC} == true ]]; then
 cat << EOF >> /etc/dnsmasq.d/pod-gateway.conf
   # Enable DNSSEC validation and caching
   conf-file=/usr/share/dnsmasq/trust-anchors.conf
   dnssec
 EOF
+fi
 
 for local_cidr in $DNS_LOCAL_CIDRS; do
   cat << EOF >> /etc/dnsmasq.d/pod-gateway.conf

--- a/config/settings.sh
+++ b/config/settings.sh
@@ -40,5 +40,8 @@ RESOLV_CONF_COPY=/etc/resolv_copy.conf
 # The following value can be used to to provide more stability in an unreliable network connection.
 CONNECTION_RETRY_COUNT=1
 
+# you want to disable DNSSEC with the gateway then set this to false
+GATEWAY_ENABLE_DNSSEC=true
+
 # If you use nftables for iptables you need to set this to yes
 IPTABLES_NFT=no


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**
Having dnssec enabled doesn't work in my environment as my upstream local dns servers (samba) don't support dnssec. This is achieved by and extra environment variable `GATEWAY_ENABLE_DNSSEC` which defaults to `true` to keep the existing behaviour.

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**
This change will allow the PR22 "Add DNSSEC Support " from the k8athome repo to be optionally reverted. A

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
