### PR TITLE
Fix mtu wireguard

### DIFF
--- a/bin/client_init.sh
+++ b/bin/client_init.sh
@@ -57,6 +57,9 @@ ping -c "${CONNECTION_RETRY_COUNT}" "$GATEWAY_IP"
 ip link add vxlan0 type vxlan id "$VXLAN_ID" dev eth0 dstport 0 || true
 bridge fdb append to 00:00:00:00:00:00 dst "$GATEWAY_IP" dev vxlan0
 ip link set up dev vxlan0
+if [ "${VPN_INTERFACE:-tun0}" = "wg0" ];then
+    ip link set mtu 1420 dev vxlan0
+fi
 
 cat << EOF > /etc/dhclient.conf
 backoff-cutoff 2;

--- a/bin/gateway_init.sh
+++ b/bin/gateway_init.sh
@@ -30,6 +30,9 @@ VXLAN_GATEWAY_IP="${VXLAN_IP_NETWORK}.1"
 ip link add vxlan0 type vxlan id $VXLAN_ID dev eth0 dstport 0 || true
 ip addr add ${VXLAN_GATEWAY_IP}/24 dev vxlan0 || true
 ip link set up dev vxlan0
+if [ "${VPN_INTERFACE:-tun0}" = "wg0" ];then
+    ip link set mtu 1420 dev vxlan0
+fi
 
 # check if rule already exists (retry)
 if ! ip rule | grep -q "from all lookup main suppress_prefixlength 0"; then


### PR DESCRIPTION
**Description of the change**

set mtu to 1420 when use wireguard interface. Because wireguard use a mtu of 1420 by [default](https://keremerkan.net/posts/wireguard-mtu-fixes/#:~:text=So%2C%20what%20makes%20this%20configuration,the%20post%20for%20my%20reasoning).) for wg0.

![image](https://github.com/angelnu/pod-gateway/assets/50653464/8cfd516f-5fff-497c-ab76-5fc5bd914d6a)

So we need to set vxlan0 to the same, without this it's impossible to make a TLS request.
Operation like apk update/add that require https connection will miss 1/9 because TLS packet [cannot be fragmented]( https://unix.stackexchange.com/questions/252977/curl-hangs-after-client-hello). 


**Benefits**

Check if VPN_INTERFACE is set to wg0 in env var. So if true set correct MTU to vxlan0 interface.

**Possible drawbacks**

Nothing as my see.

**Applicable issues**

I don't have opened issue for this, I can do it if it's necessary. I've talk about it on [k8s-at-home discord](https://discord.com/channels/673534664354430999/1118815599175422032)


**Additional information**

It will be nice if someone who use wireguard VPN can test if the issue affect all user of wireguard. Or if is only my VPN provider cause this issue.
