### PR TITLE
chore(ipv6): We don't currently support it so block it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /
 # coreutils -> need REAL chown and chmod for dhclient (it uses reference option not supported in busybox)
 # bash -> for scripting logic
 # inotify-tools -> inotifyd for dnsmask resolv.conf reload circumvention
-RUN apk add --no-cache coreutils dnsmasq-dnssec iproute2 bind-tools dhclient bash inotify-tools
+RUN apk add --no-cache coreutils dnsmasq-dnssec iproute2 bind-tools dhclient bash inotify-tools ip6tables
 
 COPY config /default_config
 COPY config /config

--- a/bin/client_init.sh
+++ b/bin/client_init.sh
@@ -24,6 +24,10 @@ fi
 echo "Deleting existing default GWs"
 ip route del 0/0 || /bin/true
 
+# We don't support IPv6 at the moment, so delete default route to prevent leaking traffic.
+echo "Deleting existing default IPv6 route to prevent leakage"
+ip route -6 del default || /bin/true
+
 # After this point nothing should be reachable -> check
 if ping -c 1 -W 1000 8.8.8.8; then
   echo "WE SHOULD NOT BE ABLE TO PING -> EXIT"


### PR DESCRIPTION

<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

It blocks IPv6 traffic on client via deleting IPv6 default route.

**Benefits**

It doesn't leak traffic anymore on full-stack, as otherwise it would use direct IPv6 connectivity.

**Additional information**

I'm still not at all sure how we can get dual-stack VPN working on it.
