### PR TITLE
fix port forwarding in k8s environments

### DIFF
--- a/bin/client_init.sh
+++ b/bin/client_init.sh
@@ -38,10 +38,20 @@ fi
 ip addr
 ip route
 
+# Handle hostnames in K8s pod environments
+if [ -n "$KUBERNETES_SERVICE_HOST" ]; then # if this env var exists, it's probably K8s
+  # In Kubernetes, extract the base pod name before the first dash
+  HOSTNAME_REAL=$(hostname | cut -d'-' -f1)
+else
+  # In Docker or other environments, use the full hostname
+  HOSTNAME_REAL=$(hostname)
+fi
+echo $HOSTNAME_REAL
+
 # Derived settings
 K8S_DNS_IP="$(cut -d ' ' -f 1 <<< "$K8S_DNS_IPS")"
 GATEWAY_IP="$(dig +short "$GATEWAY_NAME" "@${K8S_DNS_IP}")"
-NAT_ENTRY="$(grep "^$(hostname) " /config/nat.conf || true)"
+NAT_ENTRY="$(grep "^$HOSTNAME_REAL " /config/nat.conf || true)"
 VXLAN_GATEWAY_IP="${VXLAN_IP_NETWORK}.1"
 
 # Make sure there is correct route for gateway


### PR DESCRIPTION
**Problem Statement**
In Kubernetes environments, the hostname command will return something like `pod-bcf579d67-c9plq` instead of just `pod`. And since you can't know the pod name ahead of time, the value being matched for in /config/nat.conf will be just 'pod' and will fail to match, causing the NAT_ENTRY variable to be empty and enter the dhclient if statement instead of setting the static ip logic. This means port forwarding won't work.

**Description of the change**

This change checks for the presence of the `KUBERNETES_SERVICE_HOST` environment variable to determine if the client_init.sh script is being run in k8s. If it is, it strips off the pod name after the first dash, so you'll get just the deployment name, which you can then set in pod-gateway chart values publicPorts.hostname and it will match. 

If the env variable isn't present, then it proceeds with the full value from hostname. 

**Benefits**

Port forwarding in Kubernetes will now work properly.

**Possible drawbacks**

The only limitation with this is if the deployment name has a dash in it, under those circumstances the pod name would be cut off too early. You could probably work around this by cutting off the hostname in the pod-gateway chart. 

I've tested this in my own cluster in kubernetes and it worked, the static ip was properly set to 10 per my config and the traffic is getting forwarded to my pod. https://github.com/jgilfoil/home-cluster/pull/121/files


I did not test this change in a regular docker environment.
