### PR TITLE
Cleanup old dhclient processes if the client gets inited multiple times

### DIFF
--- a/bin/client_init.sh
+++ b/bin/client_init.sh
@@ -96,6 +96,8 @@ EOF
 # Configure IP and default GW though the gateway docker
 if [[ -z "$NAT_ENTRY" ]]; then
   echo "Get dynamic IP"
+  # cleanup old processes if they exist
+  killall -q dhclient || true
   dhclient -v -cf /etc/dhclient.conf vxlan0
 else
   IP=$(cut -d' ' -f2 <<< "$NAT_ENTRY")


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->
In the event that the pod gateway is flappy the client can be init'd multiple times

I found that I had many copies of dhclient running. Cleaning them up before running another

**Benefits**

<!-- What benefits will be realized by the code change? -->
No more multiple copies of dhclient

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
