### PR TITLE
Allow setting K8S_DNS instead of getting it from default resov.conf

### DIFF
--- a/bin/gateway_sidecar.sh
+++ b/bin/gateway_sidecar.sh
@@ -14,9 +14,10 @@ if [ ! -f /etc/resolv.conf.org ]; then
   echo "/etc/resolv.conf.org written"
 fi
 
-#Get K8S DNS
-K8S_DNS=$(grep nameserver /etc/resolv.conf.org | cut -d' ' -f2)
-
+# Get K8S DNS if not set
+if [ -z "$DNS_LOCAL_SERVER" ]; then
+  DNS_LOCAL_SERVER=$(grep nameserver /etc/resolv.conf.org | cut -d' ' -f2)
+fi
 
 cat << EOF > /etc/dnsmasq.d/pod-gateway.conf
 # DHCP server settings
@@ -56,7 +57,7 @@ fi
 for local_cidr in $DNS_LOCAL_CIDRS; do
   cat << EOF >> /etc/dnsmasq.d/pod-gateway.conf
   # Send ${local_cidr} DNS queries to the K8S DNS server
-  server=/${local_cidr}/${K8S_DNS}
+  server=/${local_cidr}/${DNS_LOCAL_SERVER}
 EOF
 done
 

--- a/config/settings.sh
+++ b/config/settings.sh
@@ -30,6 +30,8 @@ VPN_LOCAL_CIDRS="10.0.0.0/8 192.168.0.0/16"
 # DNS queries to these domains will be resolved by K8S DNS instead of
 # the default (typcally the VPN client changes it)
 DNS_LOCAL_CIDRS="local"
+# Dns to use for local resolution, if unset, will use default resolv.conf
+DNS_LOCAL_SERVER=
 
 # dnsmasq monitors directories. /etc/resolv.conf in a container is in another
 # file system so it does not work. To circumvent this a copy is made using


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

Add settings option to set the local dns server instead of using the default one provided by resolv.conf

**Benefits**

Allowing to set the dns to be used, but only for resolved domains via pod-gateway dnsmasq.

**Possible drawbacks**

As its a static setting, changes to dns settings wont affect pod-gateway directly. Something to keep in mind.

**Applicable issues**

I had an issue where the K8s-nameserver from resolv.conf was 1.1.1.1 (i think based on the worker node) and neither dnsConfig.nameservers nor dnsPolicy could change it.
I made this commit to make the change regardless.

