### PR TITLE
gateway_sidecar: only consider IPv4 DNS addresses

### DIFF
--- a/bin/gateway_sidecar.sh
+++ b/bin/gateway_sidecar.sh
@@ -14,8 +14,8 @@ if [ ! -f /etc/resolv.conf.org ]; then
   echo "/etc/resolv.conf.org written"
 fi
 
-#Get K8S DNS
-K8S_DNS=$(grep nameserver /etc/resolv.conf.org | cut -d' ' -f2)
+# Get K8S DNS (only IPv4 addresses)
+K8S_DNS=$(grep 'nameserver' /etc/resolv.conf.org | awk '/nameserver [0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/ {print $2}')
 
 
 cat << EOF > /etc/dnsmasq.d/pod-gateway.conf
@@ -74,11 +74,11 @@ inotifyd=$!
 
 _kill_procs() {
   echo "Signal received -> killing processes"
-  
+
   kill -TERM $dnsmasq || /bin/true
   wait $dnsmasq
   rc=$?
-  
+
   kill -TERM $inotifyd || /bin/true
   wait $inotifyd
 


### PR DESCRIPTION
**Description of the change**

Modify the gateway sidecar to only consider IPv4 DNS addresses.

**Benefits**

It wouldn't break with dual-stack clusters.

**Possible drawbacks**

No IPv6 support

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #59
