### PR TITLE
add VXLAN_PORT allow rules, do not block on ping to pod-gateway

### DIFF
--- a/bin/client_init.sh
+++ b/bin/client_init.sh
@@ -65,7 +65,7 @@ ip addr
 ip route
 
 # Check we can connect to the GATEWAY IP
-ping -c "${CONNECTION_RETRY_COUNT}" "$GATEWAY_IP"
+ping -c "${CONNECTION_RETRY_COUNT}" "$GATEWAY_IP" || true
 
 # Create tunnel NIC
 ip link add vxlan0 type vxlan id "$VXLAN_ID" dev eth0 dstport "${VXLAN_PORT:-0}" || true

--- a/bin/gateway_init.sh
+++ b/bin/gateway_init.sh
@@ -84,6 +84,12 @@ if [[ -n "$VPN_INTERFACE" ]]; then
     done
   done </config/nat.conf
 
+  if [ -n "$VXLAN_PORT" ]; then
+    echo "Allow VXLAN traffic from eth0"
+    iptables -A INPUT -i eth0 -p udp --dport=${VXLAN_PORT} -j ACCEPT
+    iptables -A OUTPUT -o eth0 -p udp --dport=${VXLAN_PORT} -j ACCEPT
+  fi
+
   echo "Allow DHCP traffic from vxlan"
   iptables -A INPUT -i vxlan0 -p udp --sport=68 --dport=67 -j ACCEPT
 


### PR DESCRIPTION
**Description of the change**

If the VXLAN_PORT is set (e.g. 4789) additional firewall rules are required.

Additionally, the pod gateway ping in the client could not be performed (due to kubeproxy replacement) and therefore made optional. Connectivity issues are still detected either if the dhclient or the ping to gateway on VXLAN fails.

**Benefits**

Makes pod-gateway working in cilium